### PR TITLE
Override GainProcessor's valueChanged function to notify parameter changes to listeners

### DIFF
--- a/modules/squarepine_audio/effects/GainProcessor.cpp
+++ b/modules/squarepine_audio/effects/GainProcessor.cpp
@@ -1,5 +1,7 @@
-GainProcessor::GainProcessor (NormalisableRange<float> gainRange) :
-    InternalProcessor (false)
+GainProcessor::GainProcessor (const String& parameterName,
+                              NormalisableRange<float> gainRange) :
+    InternalProcessor (false),
+    name (parameterName)
 {
     auto layout = createDefaultParameterLayout();
 

--- a/modules/squarepine_audio/effects/GainProcessor.cpp
+++ b/modules/squarepine_audio/effects/GainProcessor.cpp
@@ -3,16 +3,16 @@ GainProcessor::GainProcessor (NormalisableRange<float> gainRange) :
 {
     auto layout = createDefaultParameterLayout();
 
-    auto vp = std::make_unique<AudioParameterFloat> (getIdentifier().toString(), getName(),
-                                                     gainRange, 1.0f, getName(),
-                                                     AudioProcessorParameter::outputGain,
-                                                     [] (float value, int) -> String
-                                                     {
-                                                        if (approximatelyEqual (value, 1.0f))
-                                                            return "0 dB";
+    auto vp = std::make_unique<GainParameter> (getIdentifier().toString(), getName(),
+                                               gainRange, 1.0f, getName(),
+                                               AudioProcessorParameter::outputGain,
+                                               [] (float value, int) -> String
+                                               {
+                                                    if (approximatelyEqual (value, 1.0f))
+                                                        return "0 dB";
 
-                                                        return Decibels::toString (Decibels::gainToDecibels (value));
-                                                     });
+                                                    return Decibels::toString (Decibels::gainToDecibels (value));
+                                               });
 
     gainParameter = vp.get();
     gainParameter->addListener (this);
@@ -28,7 +28,8 @@ GainProcessor::GainProcessor (NormalisableRange<float> gainRange) :
 void GainProcessor::setGain (float v)
 {
     v = std::clamp (v, getMinimumGain(), getMaximumGain());
-    gainParameter->operator= (v);
+    
+    gainParameter->juce::AudioParameterFloat::operator= (v);
 }
 
 float GainProcessor::getGain() const noexcept

--- a/modules/squarepine_audio/effects/GainProcessor.h
+++ b/modules/squarepine_audio/effects/GainProcessor.h
@@ -19,7 +19,8 @@ public:
 
         @see defaultMaximumGainLinear
     */
-    GainProcessor (NormalisableRange<float> gainRange = { 0.0f, defaultMaximumGainLinear });
+    GainProcessor (const String& parameterName = "Gain",
+                   NormalisableRange<float> gainRange = { 0.0f, defaultMaximumGainLinear });
 
     //==============================================================================
     /** Changes the gain.
@@ -51,7 +52,7 @@ public:
 
     //==============================================================================
     /** @internal */
-    const String getName() const override { return TRANS ("Gain"); }
+    const String getName() const override { return TRANS (name); }
     /** @internal */
     Identifier getIdentifier() const override { return "gain"; }
     /** @internal */
@@ -97,7 +98,7 @@ private:
     
     //==============================================================================
     GainParameter* gainParameter = nullptr;
-
+    String name;
     LinearSmoothedValue<float> floatGain { 1.0f };
     LinearSmoothedValue<double> doubleGain { 1.0 };
 

--- a/modules/squarepine_audio/effects/GainProcessor.h
+++ b/modules/squarepine_audio/effects/GainProcessor.h
@@ -68,8 +68,35 @@ public:
     void parameterGestureChanged (int, bool) override;
 
 private:
+    
+    class GainParameter : public AudioParameterFloat
+    {
+    public:
+        GainParameter (const String& parameterID,
+                       const String& parameterName,
+                       NormalisableRange<float> normalisableRange,
+                       float defaultValue,
+                       const String& parameterLabel = String(),
+                       Category parameterCategory = AudioProcessorParameter::genericParameter,
+                       std::function<String (float value, int maximumStringLength)> stringFromValue = nullptr,
+                       std::function<float (const String& text)> valueFromString = nullptr) :
+                       AudioParameterFloat (parameterID,
+                                            parameterName,
+                                            normalisableRange,
+                                            defaultValue,
+                                            parameterLabel,
+                                            parameterCategory,
+                                            stringFromValue,
+                                            valueFromString) {}
+    protected:
+        void valueChanged (float newValue) override
+        {
+            sendValueChangedMessageToListeners (newValue);
+        }
+    };
+    
     //==============================================================================
-    AudioParameterFloat* gainParameter = nullptr;
+    GainParameter* gainParameter = nullptr;
 
     LinearSmoothedValue<float> floatGain { 1.0f };
     LinearSmoothedValue<double> doubleGain { 1.0 };


### PR DESCRIPTION
Added a subclass of AudioParameterFloat in order to override valueChanged function. With this change I am able to notify GainProcessor's listeners for its parameter changes.